### PR TITLE
Added the get and post methods for the spreadsheet api

### DIFF
--- a/AppsScriptAPI/appsscript.json
+++ b/AppsScriptAPI/appsscript.json
@@ -1,0 +1,13 @@
+{
+    "timeZone": "America/Toronto",
+    "dependencies": {},
+    "exceptionLogging": "STACKDRIVER",
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/spreadsheets.currentonly"
+    ],
+    "runtimeVersion": "V8",
+    "webapp": {
+      "executeAs": "USER_DEPLOYING",
+      "access": "ANYONE_ANONYMOUS"
+    }
+  }

--- a/AppsScriptAPI/appsscript.json
+++ b/AppsScriptAPI/appsscript.json
@@ -11,3 +11,4 @@
       "access": "ANYONE_ANONYMOUS"
     }
   }
+  

--- a/AppsScriptAPI/companionCubeAPI.js
+++ b/AppsScriptAPI/companionCubeAPI.js
@@ -1,0 +1,62 @@
+// GET request 
+// get the value of cell 1,1
+function doGet(e) {
+  try {
+    // get the current spreadsheet from which this apps script was created
+    const spreadSheet = SpreadsheetApp.getActive();
+
+    const sheet = spreadSheet.getSheetByName('Sheet1');
+
+    // get the value in cell 1,1  
+    const cell = sheet.getRange(1,1); 
+    const colour = cell.getValue();
+
+    Logger.log('Current Colour: %d', colour);
+    return ContentService.createTextOutput(colour);
+  
+  } 
+  catch (error) {
+    Logger.log('Error Detected: %s', error.message);
+    return ContentService.createTextOutput("Error detected: " + error.message);
+  }
+}
+
+
+// POST request
+// set the value of cell 1,1
+function doPost(e) {
+  try { 
+    // get the event's POST body content text 
+    const body = JSON.parse(e.postData.contents);
+
+    // get the cell 1,1 object (Range object)
+    const spreadSheet = SpreadsheetApp.getActive();
+    const sheet = spreadSheet.getSheetByName('Sheet1');  
+    let cell = sheet.getRange(1,1); 
+
+    
+    // check if the property was set and is a valid integer
+    let colour;
+    if ("colour" in body){
+      colour = body.colour;
+    }else{
+      throw new Error("The body of the request must contain the colour key.");
+    }
+    
+    if (typeof colour !== "number"){
+      throw new TypeError("The colour must be an integer.");
+    } else if (colour <= 0 || colour > 10){
+      throw new Error("The colour must be an integer in the inclusive range of 1 to 10.");
+    }
+
+    // write the value in the cell 
+    cell.setValue(colour);
+
+    Logger.log('New Colour: %d', colour);
+    return ContentService.createTextOutput(colour);
+  } 
+  catch(error){
+    Logger.log('Error Detected: %s', error.message);
+    return ContentService.createTextOutput("Error detected: " + error.message);
+  } 
+}


### PR DESCRIPTION
**What was added:**
- doGet: function to get the value of cell 1,1 of a Google spreadsheet
-  doPost: function to set the value of cell 1,1 of a Google spreadsheet
- permission file where: `https://www.googleapis.com/auth/spreadsheets.currentonly` is added to the scope to limit the API's permissions to the spreadsheet it was made in

**Note:**  The API can be created by creating a spreadsheet > going to extensions > Apps Script